### PR TITLE
Updates Android.rb for Samsung Android 11

### DIFF
--- a/lib/Android.rb
+++ b/lib/Android.rb
@@ -82,7 +82,13 @@ end
 
 def find_samsung_digits(udid)
   ver = get_android_version(udid)
-  Gem::Version.new(ver) == Gem::Version.new('9.0.0') ? 13 : 19
+  if Gem::Version.new(ver) == Gem::Version.new('9.0.0')
+    13
+  elsif Gem::Version.new(ver) == Gem::Version.new('11')
+    16
+  else
+    19
+  end
 end
 
 def find_google_digits(udid)


### PR DESCRIPTION
Modified _**find_samsung_digits(udid)**_.
If Android version of a Samsung device is 11, **_find_samsung_digits_** returns 16, which is the correct value to use in **_get_device_phone_number_**.